### PR TITLE
Custom Carrier Label & Carrier Label Placement [1/2]

### DIFF
--- a/core/java/android/content/Intent.java
+++ b/core/java/android/content/Intent.java
@@ -3295,6 +3295,21 @@ public class Intent implements Parcelable, Cloneable {
     public static final String ACTION_AIRPLANE_MODE_CHANGED = "android.intent.action.AIRPLANE_MODE";
 
     /**
+     * <p>Broadcast Action: The user has changed carrier label:</p>
+     * <ul>
+     *   <li><em>state</em> - String value.</li>
+     * </ul>
+     *
+     * <p class="note">This is a protected intent that can only be sent
+     * by the system.
+     *
+     * @hide
+     */
+    //@SdkConstant(SdkConstantType.BROADCAST_INTENT_ACTION)
+    public static final String ACTION_CUSTOM_CARRIER_LABEL_CHANGED
+            = "android.intent.action.CUSTOM_CARRIER_LABEL";
+
+    /**
      * Broadcast Action: Some content providers have parts of their namespace
      * where they publish new events or items that the user may be especially
      * interested in. For these things, they may broadcast this action when the

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6097,6 +6097,41 @@ public final class Settings {
         public static final String LOCK_POWER_MENU_DISABLED = "lockscreen_power_menu_disabled";
 
         /**
+         * Status bar carrier label
+         * 0: Hide
+         * 1: Display on keyguard status bar
+         * 2: Display on Normal status bar
+         * 3: Enabled for both
+         * @hide
+         */
+        public static final String STATUS_BAR_SHOW_CARRIER = "status_bar_show_carrier";
+
+        /**
+         * custom carrier label. The value is
+         * String.
+         * @hide
+         */
+        public static final String CUSTOM_CARRIER_LABEL = "custom_carrier_label";
+
+        /**
+         * Carrier Label Custom Color
+         * @hide
+         */
+        public static final String STATUS_BAR_CARRIER_COLOR = "status_bar_carrier_color";
+
+        /**
+         * Settings for carrier label font size
+         * @hide
+         */
+        public static final String STATUS_BAR_CARRIER_FONT_SIZE = "status_bar_carrier_font_size";
+
+        /**
+         * Custom carrier label font style
+         * @hide
+         */
+        public static final String STATUS_BAR_CARRIER_FONT_STYLE = "status_bar_carrier_font_style";
+
+        /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.
          *

--- a/core/java/com/android/internal/util/cherish/CherishUtils.java
+++ b/core/java/com/android/internal/util/cherish/CherishUtils.java
@@ -17,6 +17,9 @@
 package com.android.internal.util.cherish;
 
 import android.content.Intent;
+import android.app.ActivityManager;
+import android.app.AlertDialog;
+import android.app.IActivityManager;
 import android.hardware.input.InputManager;
 import android.os.Looper;
 import android.content.Context;

--- a/packages/SystemUI/res/layout/keyguard_status_bar.xml
+++ b/packages/SystemUI/res/layout/keyguard_status_bar.xml
@@ -63,7 +63,7 @@
         android:gravity="center"
         android:visibility="gone" />
 
-    <com.android.keyguard.CarrierText
+    <com.android.systemui.cherish.carrierlabel.CarrierLabel
         android:id="@+id/keyguard_carrier_text"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/packages/SystemUI/res/layout/status_bar.xml
+++ b/packages/SystemUI/res/layout/status_bar.xml
@@ -49,6 +49,18 @@
         android:paddingTop="@dimen/status_bar_padding_top"
         android:orientation="horizontal"
         >
+
+        <com.android.systemui.cherish.carrierlabel.CarrierLabel
+            android:id="@+id/statusbar_carrier_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:gravity="start|center_vertical"
+            android:textAppearance="@style/TextAppearance.StatusBar.Clock"
+            android:paddingEnd="@dimen/status_bar_left_clock_end_padding"
+            android:visibility="gone"
+            android:singleLine="true"/>
+
         <FrameLayout
             android:layout_height="match_parent"
             android:layout_width="0dp"

--- a/packages/SystemUI/res/values/cherish_dimens.xml
+++ b/packages/SystemUI/res/values/cherish_dimens.xml
@@ -71,4 +71,7 @@
     <dimen name="qs_header_image_side_margin">4dp</dimen>
     <dimen name="qs_header_image_top_margin">4dp</dimen>
     <dimen name="qs_header_image_bottom_margin">4dp</dimen>
+  
+    <!-- Custom Carrier Label -->
+    <dimen name="status_bar_carrier_height">14dp</dimen>
 </resources>

--- a/packages/SystemUI/res/values/cherish_styles.xml
+++ b/packages/SystemUI/res/values/cherish_styles.xml
@@ -44,4 +44,10 @@
         <item name="android:layout_centerVertical">true</item>
     </style>
 
+    <!-- Custom Carrier Label -->
+    <style name="TextAppearance.StatusBar.CarrierLabel" parent="@*android:style/TextAppearance.StatusBar.Icon">
+        <item name="android:textSize">@dimen/status_bar_carrier_height</item>
+        <item name="android:textStyle">normal</item>
+    </style>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/cherish/carrierlabel/CarrierLabel.java
+++ b/packages/SystemUI/src/com/android/systemui/cherish/carrierlabel/CarrierLabel.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright (C) 2014-2015 The MoKee OpenSource Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.cherish.carrierlabel;
+
+import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.database.ContentObserver;
+import android.graphics.Color;
+import android.graphics.Rect;
+import android.graphics.Typeface;
+import android.os.Handler;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.telephony.TelephonyManager;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+import android.widget.TextView;
+
+import com.android.internal.util.cherish.CherishUtils;
+import com.android.internal.telephony.TelephonyIntents;
+
+import com.android.systemui.Dependency;
+import com.android.systemui.cherish.carrierlabel.SpnOverride;
+import com.android.systemui.plugins.DarkIconDispatcher;
+import com.android.systemui.plugins.DarkIconDispatcher.DarkReceiver;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import com.android.systemui.R;
+
+public class CarrierLabel extends TextView implements DarkReceiver {
+
+    private Context mContext;
+    private boolean mAttached;
+    private static boolean isCN;
+    private int mCarrierFontSize = 14;
+    private int mCarrierColor = 0xffffffff;
+    private int mTintColor = Color.WHITE;
+
+    private int mCarrierLabelFontStyle = FONT_NORMAL;
+    public static final int FONT_NORMAL = 0;
+    public static final int FONT_ITALIC = 1;
+    public static final int FONT_BOLD = 2;
+    public static final int FONT_BOLD_ITALIC = 3;
+    public static final int FONT_LIGHT = 4;
+    public static final int FONT_LIGHT_ITALIC = 5;
+    public static final int FONT_THIN = 6;
+    public static final int FONT_THIN_ITALIC = 7;
+    public static final int FONT_CONDENSED = 8;
+    public static final int FONT_CONDENSED_ITALIC = 9;
+    public static final int FONT_CONDENSED_LIGHT = 10;
+    public static final int FONT_CONDENSED_LIGHT_ITALIC = 11;
+    public static final int FONT_CONDENSED_BOLD = 12;
+    public static final int FONT_CONDENSED_BOLD_ITALIC = 13;
+    public static final int FONT_MEDIUM = 14;
+    public static final int FONT_MEDIUM_ITALIC = 15;
+    public static final int FONT_BLACK = 16;
+    public static final int FONT_BLACK_ITALIC = 17;
+    public static final int FONT_DANCINGSCRIPT = 18;
+    public static final int FONT_DANCINGSCRIPT_BOLD = 19;
+    public static final int FONT_COMINGSOON = 20;
+    public static final int FONT_NOTOSERIF = 21;
+    public static final int FONT_NOTOSERIF_ITALIC = 22;
+    public static final int FONT_NOTOSERIF_BOLD = 23;
+    public static final int FONT_NOTOSERIF_BOLD_ITALIC = 24;
+    public static final int GOBOLD_LIGHT = 25;
+    public static final int ROADRAGE = 26;
+    public static final int SNOWSTORM = 27;
+    public static final int GOOGLESANS = 28;
+    public static final int NEONEON = 29;
+    public static final int THEMEABLE = 30;
+    public static final int SAMSUNG = 31;
+    public static final int MEXCELLENT = 32;
+    public static final int BURNSTOWN = 33;
+    public static final int DUMBLEDOR = 34;
+    public static final int PHANTOMBOLD = 35;
+
+    Handler mHandler;
+
+    class SettingsObserver extends ContentObserver {
+        SettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        void observe() {
+            ContentResolver resolver = mContext.getContentResolver();
+            resolver.registerContentObserver(Settings.System
+                    .getUriFor(Settings.System.STATUS_BAR_CARRIER_COLOR), false, this);
+            resolver.registerContentObserver(Settings.System
+                    .getUriFor(Settings.System.STATUS_BAR_CARRIER_FONT_SIZE), false, this);
+            resolver.registerContentObserver(Settings.System
+                    .getUriFor(Settings.System.STATUS_BAR_CARRIER_FONT_STYLE), false, this);
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+	     updateColor();
+	     updateSize();
+	     updateStyle();
+        }
+    }
+
+    public CarrierLabel(Context context) {
+        this(context, null);
+    }
+
+    public CarrierLabel(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public CarrierLabel(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        mContext = context;
+        updateNetworkName(true, null, false, null);
+        mHandler = new Handler();
+        SettingsObserver settingsObserver = new SettingsObserver(mHandler);
+        settingsObserver.observe();
+        updateColor();
+        updateSize();
+        updateStyle();
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        Dependency.get(DarkIconDispatcher.class).addDarkReceiver(this);
+        if (!mAttached) {
+            mAttached = true;
+            IntentFilter filter = new IntentFilter();
+            filter.addAction(TelephonyManager.ACTION_SERVICE_PROVIDERS_UPDATED);
+            filter.addAction(Intent.ACTION_CUSTOM_CARRIER_LABEL_CHANGED);
+            mContext.registerReceiver(mIntentReceiver, filter, null, getHandler());
+        }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        Dependency.get(DarkIconDispatcher.class).removeDarkReceiver(this);
+        if (mAttached) {
+            mContext.unregisterReceiver(mIntentReceiver);
+            mAttached = false;
+        }
+    }
+
+    @Override
+    public void onDarkChanged(Rect area, float darkIntensity, int tint) {
+        mTintColor = DarkIconDispatcher.getTint(area, this, tint);
+        if (mCarrierColor == 0xFFFFFFFF) {
+            setTextColor(mTintColor);
+        } else {
+            setTextColor(mCarrierColor);
+        }
+    }
+
+    private final BroadcastReceiver mIntentReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            if (TelephonyManager.ACTION_SERVICE_PROVIDERS_UPDATED.equals(action)
+                    || Intent.ACTION_CUSTOM_CARRIER_LABEL_CHANGED.equals(action)) {
+                        updateNetworkName(intent.getBooleanExtra(TelephonyManager.EXTRA_SHOW_SPN, true),
+                        intent.getStringExtra(TelephonyManager.EXTRA_SPN),
+                        intent.getBooleanExtra(TelephonyManager.EXTRA_SHOW_PLMN, false),
+                        intent.getStringExtra(TelephonyManager.EXTRA_PLMN));
+                isCN = CherishUtils.isChineseLanguage();
+            }
+        }
+    };
+
+    void updateNetworkName(boolean showSpn, String spn, boolean showPlmn, String plmn) {
+        final String str;
+        final boolean plmnValid = showPlmn && !TextUtils.isEmpty(plmn);
+        final boolean spnValid = showSpn && !TextUtils.isEmpty(spn);
+        if (spnValid) {
+            str = spn;
+        } else if (plmnValid) {
+            str = plmn;
+        } else {
+            str = "";
+        }
+        String customCarrierLabel = Settings.System.getStringForUser(mContext.getContentResolver(),
+                Settings.System.CUSTOM_CARRIER_LABEL, UserHandle.USER_CURRENT);
+        if (!TextUtils.isEmpty(customCarrierLabel)) {
+            setText(customCarrierLabel);
+        } else {
+            setText(TextUtils.isEmpty(str) ? getOperatorName() : str);
+        }
+    }
+
+    private String getOperatorName() {
+        String operatorName = getContext().getString(R.string.quick_settings_wifi_no_network);
+        TelephonyManager telephonyManager = (TelephonyManager) getContext().getSystemService(
+                Context.TELEPHONY_SERVICE);
+        if (isCN) {
+            String operator = telephonyManager.getNetworkOperator();
+            if (TextUtils.isEmpty(operator)) {
+                operator = telephonyManager.getSimOperator();
+            }
+            SpnOverride mSpnOverride = new SpnOverride();
+            operatorName = mSpnOverride.getSpn(operator);
+        } else {
+            operatorName = telephonyManager.getNetworkOperatorName();
+        }
+        if (TextUtils.isEmpty(operatorName)) {
+            operatorName = telephonyManager.getSimOperatorName();
+        }
+        return operatorName;
+    }
+
+    public void getFontStyle(int font) {
+        switch (font) {
+            case FONT_NORMAL:
+            default:
+                setTypeface(Typeface.create("sans-serif",
+                    Typeface.NORMAL));
+                break;
+            case FONT_ITALIC:
+                setTypeface(Typeface.create("sans-serif",
+                    Typeface.ITALIC));
+                break;
+            case FONT_BOLD:
+                setTypeface(Typeface.create("sans-serif",
+                    Typeface.BOLD));
+                break;
+            case FONT_BOLD_ITALIC:
+                setTypeface(Typeface.create("sans-serif",
+                    Typeface.BOLD_ITALIC));
+                break;
+            case FONT_LIGHT:
+                setTypeface(Typeface.create("sans-serif-light",
+                    Typeface.NORMAL));
+                break;
+            case FONT_LIGHT_ITALIC:
+                setTypeface(Typeface.create("sans-serif-light",
+                    Typeface.ITALIC));
+                break;
+            case FONT_THIN:
+                setTypeface(Typeface.create("sans-serif-thin",
+                    Typeface.NORMAL));
+                break;
+            case FONT_THIN_ITALIC:
+                setTypeface(Typeface.create("sans-serif-thin",
+                    Typeface.ITALIC));
+                break;
+            case FONT_CONDENSED:
+                setTypeface(Typeface.create("sans-serif-condensed",
+                    Typeface.NORMAL));
+                break;
+            case FONT_CONDENSED_ITALIC:
+                setTypeface(Typeface.create("sans-serif-condensed",
+                    Typeface.ITALIC));
+                break;
+            case FONT_CONDENSED_LIGHT:
+                setTypeface(Typeface.create("sans-serif-condensed-light",
+                    Typeface.NORMAL));
+                break;
+            case FONT_CONDENSED_LIGHT_ITALIC:
+                setTypeface(Typeface.create("sans-serif-condensed-light",
+                    Typeface.ITALIC));
+                break;
+            case FONT_CONDENSED_BOLD:
+                setTypeface(Typeface.create("sans-serif-condensed",
+                    Typeface.BOLD));
+                break;
+            case FONT_CONDENSED_BOLD_ITALIC:
+                setTypeface(Typeface.create("sans-serif-condensed",
+                    Typeface.BOLD_ITALIC));
+                break;
+            case FONT_MEDIUM:
+                setTypeface(Typeface.create("sans-serif-medium",
+                    Typeface.NORMAL));
+                break;
+            case FONT_MEDIUM_ITALIC:
+                setTypeface(Typeface.create("sans-serif-medium",
+                    Typeface.ITALIC));
+                break;
+            case FONT_BLACK:
+                setTypeface(Typeface.create("sans-serif-black",
+                    Typeface.NORMAL));
+                break;
+            case FONT_BLACK_ITALIC:
+                setTypeface(Typeface.create("sans-serif-black",
+                    Typeface.ITALIC));
+                break;
+            case FONT_DANCINGSCRIPT:
+                setTypeface(Typeface.create("cursive",
+                    Typeface.NORMAL));
+                break;
+            case FONT_DANCINGSCRIPT_BOLD:
+                setTypeface(Typeface.create("cursive",
+                    Typeface.BOLD));
+                break;
+            case FONT_COMINGSOON:
+                setTypeface(Typeface.create("casual",
+                    Typeface.NORMAL));
+                break;
+            case FONT_NOTOSERIF:
+                setTypeface(Typeface.create("serif",
+                    Typeface.NORMAL));
+                break;
+            case FONT_NOTOSERIF_ITALIC:
+                setTypeface(Typeface.create("serif",
+                    Typeface.ITALIC));
+                break;
+            case FONT_NOTOSERIF_BOLD:
+                setTypeface(Typeface.create("serif",
+                    Typeface.BOLD));
+                break;
+            case FONT_NOTOSERIF_BOLD_ITALIC:
+                setTypeface(Typeface.create("serif",
+                    Typeface.BOLD_ITALIC));
+                break;
+            case GOBOLD_LIGHT:
+                setTypeface(Typeface.create("gobold-light-sys",
+                    Typeface.NORMAL));
+                break;
+            case ROADRAGE:
+                setTypeface(Typeface.create("roadrage-sys",
+		   Typeface.NORMAL));
+                break;
+            case SNOWSTORM:
+                setTypeface(Typeface.create("snowstorm-sys",
+                    Typeface.NORMAL));
+                break;
+            case GOOGLESANS:
+                setTypeface(Typeface.create("googlesans-sys",
+                    Typeface.NORMAL));
+                break;
+            case NEONEON:
+                setTypeface(Typeface.create("neoneon-sys",
+                    Typeface.NORMAL));
+                break;
+            case THEMEABLE:
+                setTypeface(Typeface.create("themeable-sys",
+                    Typeface.NORMAL));
+                break;
+            case SAMSUNG:
+                setTypeface(Typeface.create("samsung-sys",
+                    Typeface.NORMAL));
+                break;
+            case MEXCELLENT:
+                setTypeface(Typeface.create("mexcellent-sys",
+                    Typeface.NORMAL));
+                break;
+            case BURNSTOWN:
+                setTypeface(Typeface.create("burnstown-sys",
+                    Typeface.NORMAL));
+                break;
+            case DUMBLEDOR:
+                setTypeface(Typeface.create("dumbledor-sys",
+                    Typeface.NORMAL));
+                break;
+	    case PHANTOMBOLD:
+                setTypeface(Typeface.create("phantombold-sys",
+                    Typeface.NORMAL));
+                break;
+        }
+    }
+
+    private void updateColor() {
+        mCarrierColor = Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.STATUS_BAR_CARRIER_COLOR, 0xffffffff);
+        if (mCarrierColor == 0xFFFFFFFF) {
+            setTextColor(mTintColor);
+        } else {
+            setTextColor(mCarrierColor);
+        }
+    }
+
+    private void updateSize() {
+        mCarrierFontSize = Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.STATUS_BAR_CARRIER_FONT_SIZE, 14);
+        setTextSize(mCarrierFontSize);
+    }
+
+    private void updateStyle() {
+        mCarrierLabelFontStyle = Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.STATUS_BAR_CARRIER_FONT_STYLE, FONT_NORMAL);
+        getFontStyle(mCarrierLabelFontStyle);
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/cherish/carrierlabel/SpnOverride.java
+++ b/packages/SystemUI/src/com/android/systemui/cherish/carrierlabel/SpnOverride.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2014 The MoKee OpenSource Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.cherish.carrierlabel;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+import android.os.Environment;
+import android.telephony.Rlog;
+import android.util.Xml;
+
+import com.android.internal.util.XmlUtils;
+
+public class SpnOverride {
+    private HashMap<String, String> mCarrierSpnMap;
+
+
+    static final String LOG_TAG = "SpnOverride";
+    static final String PARTNER_SPN_OVERRIDE_PATH ="etc/spn-conf.xml";
+
+    public SpnOverride () {
+        mCarrierSpnMap = new HashMap<String, String>();
+        loadSpnOverrides();
+    }
+
+    public boolean containsCarrier(String carrier) {
+        return mCarrierSpnMap.containsKey(carrier);
+    }
+
+    public String getSpn(String carrier) {
+        return mCarrierSpnMap.get(carrier);
+    }
+
+    private void loadSpnOverrides() {
+        FileReader spnReader;
+
+        final File spnFile = new File(Environment.getRootDirectory(),
+                PARTNER_SPN_OVERRIDE_PATH);
+
+        try {
+            spnReader = new FileReader(spnFile);
+        } catch (FileNotFoundException e) {
+            Rlog.w(LOG_TAG, "Can not open " +
+                    Environment.getRootDirectory() + "/" + PARTNER_SPN_OVERRIDE_PATH);
+            return;
+        }
+
+        try {
+            XmlPullParser parser = Xml.newPullParser();
+            parser.setInput(spnReader);
+
+            XmlUtils.beginDocument(parser, "spnOverrides");
+
+            while (true) {
+                XmlUtils.nextElement(parser);
+
+                String name = parser.getName();
+                if (!"spnOverride".equals(name)) {
+                    break;
+                }
+
+                String numeric = parser.getAttributeValue(null, "numeric");
+                String data    = parser.getAttributeValue(null, "spn");
+
+                mCarrierSpnMap.put(numeric, data);
+            }
+            spnReader.close();
+        } catch (XmlPullParserException e) {
+            Rlog.w(LOG_TAG, "Exception in spn-conf parser " + e);
+        } catch (IOException e) {
+            Rlog.w(LOG_TAG, "Exception in spn-conf parser " + e);
+        }
+    }
+
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/CollapsedStatusBarFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/CollapsedStatusBarFragment.java
@@ -78,6 +78,8 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
     private View mRightClock;
     private boolean mShowClock = true;
     private final Handler mHandler = new Handler();
+    private View mCustomCarrierLabel;
+    private int mShowCarrierLabel;
 
     private View mBatteryBars[] = new View[2];
 
@@ -92,6 +94,9 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
                     false, this, UserHandle.USER_ALL);
          mContentResolver.registerContentObserver(Settings.System.getUriFor(
                     Settings.System.STATUSBAR_CLOCK_STYLE),
+                    false, this, UserHandle.USER_ALL);
+         mContentResolver.registerContentObserver(Settings.System.getUriFor(
+                    Settings.System.STATUS_BAR_SHOW_CARRIER),
                     false, this, UserHandle.USER_ALL);
        }
 
@@ -144,7 +149,8 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
         mClockView = mStatusBar.findViewById(R.id.clock);
         mCenterClockLayout = (LinearLayout) mStatusBar.findViewById(R.id.center_clock_layout);
         mRightClock = mStatusBar.findViewById(R.id.right_clock);
-		mBatteryBars[0] = mStatusBar.findViewById(R.id.battery_bar);
+        mCustomCarrierLabel = mStatusBar.findViewById(R.id.statusbar_carrier_text);
+ 		mBatteryBars[0] = mStatusBar.findViewById(R.id.battery_bar);
         mBatteryBars[1] = mStatusBar.findViewById(R.id.battery_bar_1);
         showSystemIconArea(false);
         initEmergencyCryptkeeperText();
@@ -229,10 +235,12 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
         if ((diff1 & DISABLE_NOTIFICATION_ICONS) != 0) {
             if ((state1 & DISABLE_NOTIFICATION_ICONS) != 0) {
                 hideNotificationIconArea(animate);
+                hideCarrierName(animate);
                 animateHide(mClockView, animate, false);
             } else {
                 showNotificationIconArea(animate);
                 updateClockStyle(animate);
+                showCarrierName(animate);
             }
         }
     }
@@ -348,6 +356,18 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
         }
     }
 
+        public void hideCarrierName(boolean animate) {
+        if (mCustomCarrierLabel != null) {
+            animateHide(mCustomCarrierLabel, animate, true);
+        }
+    }
+
+    public void showCarrierName(boolean animate) {
+        if (mCustomCarrierLabel != null) {
+            setCarrierLabel(animate);
+        }
+    }
+
     /**
      * Hides a view.
      */
@@ -435,6 +455,9 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
         mShowClock = Settings.System.getIntForUser(mContentResolver,
                 Settings.System.STATUS_BAR_CLOCK, 1,
                 UserHandle.USER_CURRENT) == 1;
+        mShowCarrierLabel = Settings.System.getIntForUser(mContentResolver,
+                Settings.System.STATUS_BAR_SHOW_CARRIER, 1,
+                UserHandle.USER_CURRENT);
         if (!mShowClock) {
             mClockStyle = 1; // internally switch to centered clock layout because
                              // left & right will show up again after QS pulldown
@@ -444,6 +467,7 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
                     UserHandle.USER_CURRENT);
         }
         updateClockStyle(animate);
+        setCarrierLabel(animate);
     }
 
     private void updateClockStyle(boolean animate) {
@@ -453,6 +477,14 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
             if (((Clock)mClockView).isClockVisible()) {
                  animateShow(mClockView, animate);
             }
+        }
+    }
+
+    private void setCarrierLabel(boolean animate) {
+        if (mShowCarrierLabel == 2 || mShowCarrierLabel == 3) {
+            animateShow(mCustomCarrierLabel, animate);
+        } else {
+            animateHide(mCustomCarrierLabel, animate, false);
         }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardStatusBarView.java
@@ -24,7 +24,12 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Rect;
+import android.database.ContentObserver;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.UserHandle;
+import android.provider.Settings;
 import android.util.AttributeSet;
 import android.util.Pair;
 import android.util.TypedValue;
@@ -78,6 +83,8 @@ public class KeyguardStatusBarView extends RelativeLayout
     private boolean mKeyguardUserSwitcherShowing;
     private boolean mBatteryListening;
 
+    private int mShowCarrierLabel;
+
     private TextView mCarrierLabel;
     private MultiUserSwitch mMultiUserSwitch;
     private ImageView mMultiUserAvatar;
@@ -107,8 +114,21 @@ public class KeyguardStatusBarView extends RelativeLayout
     // right and left padding applied to this view to account for cutouts and rounded corners
     private Pair<Integer, Integer> mPadding = new Pair(0, 0);
 
+    private ContentObserver mObserver = new ContentObserver(new Handler()) {
+        public void onChange(boolean selfChange, Uri uri) {
+            showStatusBarCarrier();
+            updateVisibilities();
+        }
+    };
+
     public KeyguardStatusBarView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        showStatusBarCarrier();
+    }
+
+    private void showStatusBarCarrier() {
+        mShowCarrierLabel = Settings.System.getIntForUser(getContext().getContentResolver(),
+                Settings.System.STATUS_BAR_SHOW_CARRIER, 1, UserHandle.USER_CURRENT);
     }
 
     @Override
@@ -209,6 +229,13 @@ public class KeyguardStatusBarView extends RelativeLayout
             }
         }
         mBatteryView.setForceShowPercent(mBatteryCharging && mShowPercentAvailable);
+        if (mCarrierLabel != null) {
+            if (mShowCarrierLabel == 1 || mShowCarrierLabel == 3) {
+                mCarrierLabel.setVisibility(View.VISIBLE);
+            } else {
+                mCarrierLabel.setVisibility(View.GONE);
+            }
+        }
     }
 
     private void updateSystemIconsLayoutParams() {
@@ -349,6 +376,8 @@ public class KeyguardStatusBarView extends RelativeLayout
         mIconManager = new TintedIconManager(findViewById(R.id.statusIcons),
                 Dependency.get(CommandQueue.class));
         Dependency.get(StatusBarIconController.class).addIconGroup(mIconManager);
+        getContext().getContentResolver().registerContentObserver(Settings.System.getUriFor(
+		        Settings.System.STATUS_BAR_SHOW_CARRIER), false, mObserver);
         onThemeChanged();
     }
 


### PR DESCRIPTION
Squash Of:
Keyguard/Statusbar Carrier label options [1/2]
* Stock behavior(only on keyguard), only on statusbar,both disabled or both enabled
* code originally writted by @Altaf-Mahdi i just squased into one commit
PureNexusProject-Legacy/android_frameworks_base@688d56f

Show carrier label / custom & change color [1/2]
*code originally written by @martincz
*includes various fixs by the du team
PureNexusProject-Legacy/android_frameworks_base@16a247a

Carrier label - fix capitilization bug
PureNexusProject-Legacy/android_frameworks_base@4b9e22b

remove carrier label color and make carrier label play nice with dark statusbar
PureNexusProject-Legacy/android_frameworks_base@3f32102

Fix Carrier Label font size not changing on system font size change
DirtyUnicorns/android_frameworks_base@8da9dcf

include carrier label in icon merger width calculation
PureNexusProject-Legacy/android_frameworks_base@9df3a0c

Credit/Thanks to @Altaf-Mahdi @beanstown106 @dwitherell and @martincz

BenzoEdit: Fixed statusbar layout for pie
@SKULSHADY: Code cleanup and improvements
@ZeNiXxX: Fix imports for Android 10
Change-Id: I81157dd09d058b70a3e19a8242c81765bc6d6282