### PR TITLE
Fix livedisplay permissions

### DIFF
--- a/data/etc/com.android.settings.xml
+++ b/data/etc/com.android.settings.xml
@@ -16,6 +16,7 @@
   -->
 <permissions>
     <privapp-permissions package="com.android.settings">
+        <permission name="lineageos.permission.MANAGE_LIVEDISPLAY"/>
         <permission name="android.permission.ACCESS_CHECKIN_PROPERTIES"/>
         <permission name="android.permission.ACCESS_NOTIFICATIONS"/>
         <permission name="android.permission.BACKUP"/>

--- a/data/etc/com.android.systemui.xml
+++ b/data/etc/com.android.systemui.xml
@@ -16,6 +16,7 @@
   -->
 <permissions>
     <privapp-permissions package="com.android.systemui">
+        <permission name="lineageos.permission.MANAGE_LIVEDISPLAY"/>
         <permission name="android.permission.CAPTURE_AUDIO_OUTPUT"/>
         <permission name="android.permission.BATTERY_STATS"/>
         <permission name="android.permission.BIND_APPWIDGET"/>


### PR DESCRIPTION
Got bootloop without these permissions

log:
04-14 14:37:12.208  3794  3794 E AndroidRuntime: java.lang.IllegalStateException: Signature|privileged permissions not in privapp-permissions whitelist: {com.android.settings (/system/system_ext/priv-app/Settings): lineageos.permission.MANAGE_LIVEDISPLAY, com.android.systemui (/system/system_ext/priv-app/SystemUI): lineageos.permission.MANAGE_LIVEDISPLAY}

Permissions added, rom boots fine.