### PR TITLE
SystemUI: Add AOD QS tile

### DIFF
--- a/packages/SystemUI/res/drawable/ic_qs_aod.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_aod.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M17,19 L17,5 L7,5 L7,19 L17,19 M17,1 C18.1046,1,19,1.89543,19,3 L19,21 C19,22.1046,18.1046,23,17,23 L7,23 C5.89,23,5,22.1,5,21 L5,3 C5,1.89,5.89,1,7,1 L17,1 M9,7 L15,7 L15,9 L9,9 L9,7" />
+</vector>

--- a/packages/SystemUI/res/values/cherish_strings.xml
+++ b/packages/SystemUI/res/values/cherish_strings.xml
@@ -241,4 +241,8 @@
 	<!-- Gaming mode -->
     <string name="gaming_mode_not_enabled">Gaming mode is disabled in settings</string>
     <string name="quick_settings_gaming_mode_label">Gaming mode</string>
+    
+	<!-- AOD QS tile -->
+    <string name="quick_settings_aod_label">AOD</string>
+    <string name="quick_settings_aod_off_powersave_label">AOD off\nBattery saver</string>
 </resources>

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -114,7 +114,7 @@
 
     <!-- Tiles native to System UI. Order should match "quick_settings_tiles_default" -->
     <string name="quick_settings_tiles_stock" translatable="false">
-        wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,nfc,location,dataswitch,hotspot,gaming,headphonesbuddy,inversion,saver,dark,work,killapp,livedisplay,reading_mode,cast,night,screenrecord,reverse,nfc,lte,sound,caffeine,heads_up,usb_tether,sleepscreen,ambient_display,screenshot,hwkeys,compass,cpuinfo,smartpixels,soundsearch,mono,weather,dc_dimming,powermenu,anti_flicker
+wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,nfc,location,dataswitch,hotspot,gaming,headphonesbuddy,inversion,saver,dark,work,killapp,livedisplay,reading_mode,cast,night,screenrecord,reverse,nfc,lte,sound,caffeine,heads_up,usb_tether,sleepscreen,ambient_display,aod,screenshot,hwkeys,compass,cpuinfo,smartpixels,soundsearch,mono,weather,dc_dimming,powermenu,anti_flicker
     </string>
 
     <!-- The tiles to display in QuickSettings -->

--- a/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSFactoryImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSFactoryImpl.java
@@ -28,6 +28,7 @@ import com.android.systemui.qs.QSHost;
 import com.android.systemui.qs.external.CustomTile;
 import com.android.systemui.qs.tiles.AirplaneModeTile;
 import com.android.systemui.qs.tiles.AmbientDisplayTile;
+import com.android.systemui.qs.tiles.AODTile;
 import com.android.systemui.qs.tiles.AntiFlickerTile;
 import com.android.systemui.qs.tiles.BatterySaverTile;
 import com.android.systemui.qs.tiles.BluetoothTile;
@@ -108,6 +109,7 @@ public class QSFactoryImpl implements QSFactory {
     private final Provider<AntiFlickerTile> mAntiFlickerTileProvider;
     private final Provider<CaffeineTile> mCaffeineTileProvider;
     private final Provider<HeadsUpTile> mHeadsUpTileProvider;
+    private final Provider<AODTile> mAODTileProvider;
     private final Provider<PowerMenuTile> mPowerMenuTileProvider;
     private final Provider<UsbTetherTile> mUsbTetherTileProvider;
     private final Provider<SleepScreenTile> mSleepScreenTileProvider;
@@ -174,7 +176,8 @@ public class QSFactoryImpl implements QSFactory {
             Provider<SmartPixelsTile> smartPixelsTileProvider,
             Provider<SoundSearchTile> soundSearchTileProvider,
             Provider<MonoToggleTile> monoToggleTileProvider,
-            Provider<KillappTile> killappTileProvider) {
+            Provider<KillappTile> killappTileProvider,
+            Provider<AODTile> aodTileProvider) {
         mQsHostLazy = qsHostLazy;
         mWifiTileProvider = wifiTileProvider;
         mBluetoothTileProvider = bluetoothTileProvider;
@@ -220,6 +223,7 @@ public class QSFactoryImpl implements QSFactory {
         mMonoToggleTileProvider = monoToggleTileProvider;
         mKillappTileProvider = killappTileProvider;
         mDcDimmingTileProvider = dcDimTileProvider;
+        mAODTileProvider = aodTileProvider;
     }
 
     public QSTile createTile(String tileSpec) {
@@ -319,6 +323,8 @@ public class QSFactoryImpl implements QSFactory {
                 return mKillappTileProvider.get();
             case "dc_dimming":
                 return mDcDimmingTileProvider.get();
+            case "aod":
+                return mAODTileProvider.get();
         }
 
         // Custom tiles

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/AODTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/AODTile.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2018 The OmniROM Project
+ *               2020 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.qs.tiles;
+
+import android.content.Intent;
+import android.provider.Settings;
+import android.service.quicksettings.Tile;
+
+import com.android.systemui.R;
+import com.android.systemui.plugins.qs.QSTile.BooleanState;
+import com.android.systemui.qs.QSHost;
+import com.android.systemui.qs.SecureSetting;
+import com.android.systemui.qs.tileimpl.QSTileImpl;
+import com.android.systemui.statusbar.policy.BatteryController;
+
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+
+import javax.inject.Inject;
+
+public class AODTile extends QSTileImpl<BooleanState> implements
+        BatteryController.BatteryStateChangeCallback {
+
+    private final Icon mIcon = ResourceIcon.get(R.drawable.ic_qs_aod);
+    private final BatteryController mBatteryController;
+
+    private final SecureSetting mSetting;
+
+    @Inject
+    public AODTile(QSHost host, BatteryController batteryController) {
+        super(host);
+
+        mSetting = new SecureSetting(mContext, mHandler, Settings.Secure.DOZE_ALWAYS_ON) {
+            @Override
+            protected void handleValueChanged(int value, boolean observedChange) {
+                handleRefreshState(value);
+            }
+        };
+
+        mBatteryController = batteryController;
+        batteryController.observe(getLifecycle(), this);
+    }
+
+    @Override
+    public void onPowerSaveChanged(boolean isPowerSave) {
+        refreshState();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_dozeAlwaysOnDisplayAvailable);
+    }
+
+    @Override
+    public BooleanState newTileState() {
+        BooleanState state = new BooleanState();
+        state.handlesLongClick = false;
+        return state;
+    }
+
+    @Override
+    public void handleClick() {
+        setEnabled(!mState.value);
+        refreshState();
+    }
+
+    @Override
+    public Intent getLongClickIntent() {
+        return null;
+    }
+
+    private void setEnabled(boolean enabled) {
+        Settings.Secure.putInt(mContext.getContentResolver(),
+                Settings.Secure.DOZE_ALWAYS_ON,
+                enabled ? 1 : 0);
+    }
+
+    @Override
+    public CharSequence getTileLabel() {
+        if (mBatteryController.isAodPowerSave()) {
+            return mContext.getString(R.string.quick_settings_aod_off_powersave_label);
+        }
+        return mContext.getString(R.string.quick_settings_aod_label);
+    }
+
+    @Override
+    protected void handleUpdateState(BooleanState state, Object arg) {
+        final int value = arg instanceof Integer ? (Integer) arg : mSetting.getValue();
+        final boolean enable = value != 0;
+        if (state.slash == null) {
+            state.slash = new SlashState();
+        }
+        state.icon = mIcon;
+        state.value = enable;
+        state.slash.isSlashed = state.value;
+        state.label = mContext.getString(R.string.quick_settings_aod_label);
+        if (mBatteryController.isAodPowerSave()) {
+            state.state = Tile.STATE_UNAVAILABLE;
+        } else {
+            state.state = enable ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE;
+        }
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.CHERISH_SETTINGS;
+    }
+
+    @Override
+    public void handleSetListening(boolean listening) {
+    }
+}


### PR DESCRIPTION
Author: Marko Man <darkobas@gmail.com>
Date:   Wed Apr 18 13:22:52 2018 +0200

    base: SystemUI: add qs AOD tile

    Change-Id: I0d9948dbd48e309d8fcc9b2c33be8b17810dc5b0

Author: shagbag913 <sh4gbag913@gmail.com>
Date:   Sun Mar 1 15:49:17 2020 -0500

    AODTile: disable tile when power save mode is on

    AOD is not allowed when power save mode is active, reflect that upon the
    tile.

    Signed-off-by: NurKeinNeid <mralexman3000@gmail.com>
    Change-Id: I3fc7f2a33d25a1616e8df5698ca2bc2a23d45cbb

Author: Bruno Martins <bgcngm@gmail.com>
Date:   Sun Apr 12 19:04:24 2020 +0100

    AODTile: Explicitely disable long clicks

    Returning null in the getLongClickIntent() method is not enough to disable
    tile long clock and results in crashes:

      E AndroidRuntime: FATAL EXCEPTION: main
      E AndroidRuntime: Process: com.android.systemui, PID: 1391
      E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.resolveTypeIfNeeded(android.content.ContentResolver)' on a null object reference
      E AndroidRuntime:     at android.app.ApplicationPackageManager.queryIntentActivitiesAsUser(ApplicationPackageManager.java:1062)
      E AndroidRuntime:     at com.android.systemui.ActivityIntentHelper.getTargetActivityInfo(ActivityIntentHelper.java:70)
      E AndroidRuntime:     at com.android.systemui.ActivityIntentHelper.wouldLaunchResolverActivity(ActivityIntentHelper.java:47)
      E AndroidRuntime:     at com.android.systemui.statusbar.phone.StatusBar.startActivityDismissingKeyguard(StatusBar.java:2724)
      E AndroidRuntime:     at com.android.systemui.statusbar.phone.StatusBar.startActivityDismissingKeyguard(StatusBar.java:2709)
      E AndroidRuntime:     at com.android.systemui.statusbar.phone.StatusBar.startActivityDismissingKeyguard(StatusBar.java:2716)
      E AndroidRuntime:     at com.android.systemui.statusbar.phone.StatusBar.handleStartActivityDismissingKeyguard(StatusBar.java:3159)
      E AndroidRuntime:     at com.android.systemui.statusbar.phone.StatusBar.lambda$postStartActivityDismissingKeyguard$26$StatusBar(StatusBar.java:3155)
      E AndroidRuntime:     at com.android.systemui.statusbar.phone.-$$Lambda$StatusBar$CSd9n4rtnrfFyOdT2eTFRNUO5xM.run(Unknown Source:4)
      E AndroidRuntime:     at android.os.Handler.handleCallback(Handler.java:883)
      E AndroidRuntime:     at android.os.Handler.dispatchMessage(Handler.java:100)
      E AndroidRuntime:     at android.os.Looper.loop(Looper.java:214)
      E AndroidRuntime:     at android.app.ActivityThread.main(ActivityThread.java:7356)
      E AndroidRuntime:     at java.lang.reflect.Method.invoke(Native Method)
      E AndroidRuntime:     at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:491)
      E AndroidRuntime:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)

    Change-Id: Ia7d4da4723600c47bedbfeb4b9152924a50d52dd

Author: Bruno Martins <bgcngm@gmail.com>
Date:   Tue Jun 9 21:47:24 2020 +0100

    AODTile: Rewrite AOD setting handling

    This fixes the tile status on clean installs, which was showing as
    active despite AOD being disabled.

    Change-Id: I148cfb34938165395bc52c830d1f2e374b5427df

Change-Id: I5249106fea3518e8fa69990d1aa13c21cc542cb1
Signed-off-by: aswin7469 <aswinas@pixysos.com>