### PR TITLE
Fix for Statusbar Vowifi icon overlap mobile signal icon. 2/2

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/MobileSignalController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/MobileSignalController.java
@@ -113,7 +113,7 @@ public class MobileSignalController extends SignalController<
     private int mVoLTEstyle;
 
     // VoWiFi Icon
-    private int mVoWiFiIcon;
+    private boolean mVoWiFiIcon;
     private boolean mIsVowifiAvailable;
     // VoWiFi Icon Style
     private int mVoWiFistyle;
@@ -242,7 +242,7 @@ public class MobileSignalController extends SignalController<
 
         mVoWiFiIcon = Settings.System.getIntForUser(resolver,
                 Settings.System.VOWIFI_ICON, 0,
-                UserHandle.USER_CURRENT);
+                UserHandle.USER_CURRENT) == 1;
         mVoWiFistyle = Settings.System.getIntForUser(resolver,
                 Settings.System.VOWIFI_ICON_STYLE, 0,
                 UserHandle.USER_CURRENT);
@@ -499,10 +499,6 @@ public class MobileSignalController extends SignalController<
     private int getVolteResId() {
         int resId = 0;
 
-        if (mVoWiFiIcon == 2 && isVowifiAvailable()) {
-            return resId;
-        }
-
         if (mCurrentState.imsRegistered && (mCurrentState.voiceCapable ||
                   mCurrentState.videoCapable) && mVoLTEicon) {
             switch(mVoLTEstyle) {
@@ -546,6 +542,49 @@ public class MobileSignalController extends SignalController<
         }
         return resId;
     }
+	
+    // VL -VoWifi-Fix
+    private int getVowifiResId() {
+        int resId = 0;
+
+        if (mCurrentState.imsRegistered && (mCurrentState.voiceCapable ||
+                  mCurrentState.videoCapable)) {
+            switch(mVoWiFistyle) {
+				// OOS
+                case 1:
+                    resId = R.drawable.ic_vowifi_oneplus;
+                    break;
+                // Motorola
+                case 2:
+                    resId = R.drawable.ic_vowifi_moto;
+                    break;
+                // ASUS
+                case 3:
+                    resId = R.drawable.ic_vowifi_asus;
+                    break;
+                // EMUI (Huawei P10)
+                case 4:
+                    resId = R.drawable.ic_vowifi_emui;
+                    break;
+                // Simple1
+                case 5:
+                    resId = R.drawable.ic_vowifi_simple1;
+                    break;
+                // Simple2
+                case 6:
+                    resId = R.drawable.ic_vowifi_simple2;
+                    break;
+                // Simple3
+                case 7:
+                    resId = R.drawable.ic_vowifi_simple3;
+                    break;
+                default:
+                    resId = R.drawable.ic_vowifi;
+                    break;
+            }
+        }
+        return resId;
+    } 
 
     private void setListeners() {
         if (mImsManager == null) {
@@ -641,17 +680,17 @@ public class MobileSignalController extends SignalController<
                 && mCurrentState.activityOut;
         showDataIcon &= mCurrentState.isDefault || dataDisabled;
         int typeIcon = (showDataIcon || mConfig.alwaysShowDataRatIcon) ? icons.mDataType : 0;
-        int volteIcon = isVolteSwitchOn() ? getVolteResId() : 0;
-
-        MobileIconGroup vowifiIconGroup = getVowifiIconGroup();
-        if ( vowifiIconGroup != null && (mVoWiFiIcon >= 1) ) {
-            typeIcon = vowifiIconGroup.mDataType;
-            statusIcon = new IconState(true,
-                    mCurrentState.enabled && !mCurrentState.airplaneMode? statusIcon.icon : 0,
-                    statusIcon.contentDescription);
-        }
+        //int volteIcon = isVolteSwitchOn() ? getVolteResId() : 0; // VL
+        int voltewifiIcon = 0;
+        if (mVoWiFiIcon && isVowifiAvailable()) {
+		voltewifiIcon = getVowifiResId();
+	}
+	else {
+		voltewifiIcon = isVolteSwitchOn() ? getVolteResId() : 0;
+	} 
+	
         callback.setMobileDataIndicators(statusIcon, qsIcon, typeIcon, qsTypeIcon,
-                activityIn, activityOut, volteIcon, dataContentDescription, dataContentDescriptionHtml,
+                activityIn, activityOut, voltewifiIcon, dataContentDescription, dataContentDescriptionHtml,
                 description, icons.mIsWide, mSubscriptionInfo.getSubscriptionId(),
                 mCurrentState.roaming);
     }
@@ -883,39 +922,7 @@ public class MobileSignalController extends SignalController<
                 || mIsVowifiAvailable);
     }
 
-    private MobileIconGroup getVowifiIconGroup() {
-        if ( isVowifiAvailable() && !isCallIdle() ) {
-            return TelephonyIcons.VOWIFI_CALLING;
-        }else if (isVowifiAvailable()) {
-            switch(mVoWiFistyle) {
-                // OOS
-                case 1:
-                    return TelephonyIcons.VOWIFI_ONEPLUS;
-                // Motorola
-                case 2:
-                    return TelephonyIcons.VOWIFI_MOTO;
-                // ASUS
-                case 3:
-                    return TelephonyIcons.VOWIFI_ASUS;
-                // EMUI (Huawei P10)
-                case 4:
-                    return TelephonyIcons.VOWIFI_EMUI;
-                // Simple1
-                case 5:
-                    return TelephonyIcons.VOWIFI_Simple1;
-                // Simple2
-                case 6:
-                    return TelephonyIcons.VOWIFI_Simple2;
-                // Simple3
-                case 7:
-                    return TelephonyIcons.VOWIFI_Simple3;
-                default:
-                    return TelephonyIcons.VOWIFI;
-            }
-        }else {
-            return null;
-        }
-    }
+    
 
     @Override
     public void dump(PrintWriter pw) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/TelephonyIcons.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/TelephonyIcons.java
@@ -41,13 +41,6 @@ class TelephonyIcons {
     static final int ICON_5G_PLUS = R.drawable.ic_5g_plus_mobiledata;
     static final int ICON_VOWIFI = R.drawable.ic_vowifi;
     static final int ICON_VOWIFI_CALLING = R.drawable.ic_vowifi_calling;
-    static final int ICON_VOWIFI_ASUS = R.drawable.ic_vowifi_asus;
-    static final int ICON_VOWIFI_MOTO = R.drawable.ic_vowifi_moto;
-    static final int ICON_VOWIFI_ONEPLUS = R.drawable.ic_vowifi_oneplus;
-    static final int ICON_VOWIFI_EMUI = R.drawable.ic_vowifi_emui;
-    static final int ICON_VOWIFI_Simple1 = R.drawable.ic_vowifi_simple1;
-    static final int ICON_VOWIFI_Simple2 = R.drawable.ic_vowifi_simple2;
-    static final int ICON_VOWIFI_Simple3 = R.drawable.ic_vowifi_simple3;
     static final int ICON_DATA_DISABLED = R.drawable.stat_sys_data_disabled;
 
     static final MobileIconGroup CARRIER_NETWORK_CHANGE = new MobileIconGroup(
@@ -311,96 +304,7 @@ class TelephonyIcons {
             TelephonyIcons.ICON_VOWIFI_CALLING,
             false);
 
-    static final MobileIconGroup VOWIFI_MOTO = new MobileIconGroup(
-            "VoWIFI_Moto",
-            null,
-            null,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH,
-            0, 0,
-            0,
-            0,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH[0],
-            0,
-            TelephonyIcons.ICON_VOWIFI_MOTO,
-            false);
-
-    static final MobileIconGroup VOWIFI_ASUS = new MobileIconGroup(
-            "VoWIFI_ASUS",
-            null,
-            null,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH,
-            0, 0,
-            0,
-            0,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH[0],
-            0,
-            TelephonyIcons.ICON_VOWIFI_ASUS,
-            false);
-
-    static final MobileIconGroup VOWIFI_ONEPLUS = new MobileIconGroup(
-            "VoWIFI_OnePlus",
-            null,
-            null,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH,
-            0, 0,
-            0,
-            0,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH[0],
-            0,
-            TelephonyIcons.ICON_VOWIFI_ONEPLUS,
-            false);
-
-    static final MobileIconGroup VOWIFI_EMUI = new MobileIconGroup(
-            "VoWIFI_Emui",
-            null,
-            null,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH,
-            0, 0,
-            0,
-            0,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH[0],
-            0,
-            TelephonyIcons.ICON_VOWIFI_EMUI,
-            false);
-	    
-    static final MobileIconGroup VOWIFI_Simple1 = new MobileIconGroup(
-            "VoWIFI_Simple1",
-            null,
-            null,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH,
-            0, 0,
-            0,
-            0,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH[0],
-            0,
-            TelephonyIcons.ICON_VOWIFI_Simple1,
-            false);
-	    
-    static final MobileIconGroup VOWIFI_Simple2 = new MobileIconGroup(
-            "VoWIFI_Simple2",
-            null,
-            null,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH,
-            0, 0,
-            0,
-            0,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH[0],
-            0,
-            TelephonyIcons.ICON_VOWIFI_Simple2,
-            false);
-	    
-    static final MobileIconGroup VOWIFI_Simple3 = new MobileIconGroup(
-            "VoWIFI_Simple3",
-            null,
-            null,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH,
-            0, 0,
-            0,
-            0,
-            AccessibilityContentDescriptions.PHONE_SIGNAL_STRENGTH[0],
-            0,
-            TelephonyIcons.ICON_VOWIFI_Simple3,
-            false);
+    
 
     /** Mapping icon name(lower case) to the icon object. */
     static final Map<String, MobileIconGroup> ICON_NAME_TO_ICON;


### PR DESCRIPTION
Changed to switch to enable (replace VoLTE) or disable VoWifi icon (CherishSettings). If enabled the VoWifi icon will replace the VoLTE icon on the statusbar if the service is available (frameworks base).