### PR TITLE
SystemUI: Hide lockscreen media art if nothing is playing

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/NotificationMediaManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NotificationMediaManager.java
@@ -729,7 +729,9 @@ public class NotificationMediaManager implements Dumpable {
             }
         }
 
-        if ((hasArtwork || DEBUG_MEDIA_FAKE_ARTWORK)
+        // show artwork only if the media is playing
+        if (PlaybackState.STATE_PLAYING == getMediaControllerPlaybackState(mMediaController)
+                && (hasArtwork || DEBUG_MEDIA_FAKE_ARTWORK)
                 && (mStatusBarStateController.getState() != StatusBarState.SHADE || allowWhenShade)
                 &&  mBiometricUnlockController != null && mBiometricUnlockController.getMode()
                         != BiometricUnlockController.MODE_WAKE_AND_UNLOCK_PULSING


### PR DESCRIPTION
it's annoying to get the artwork even if the notification gets
swiped out and media is paused, because the media session is still alive

Change-Id: I3540e1429524d34029d273c5cbe216fa46e4d59e