### PR TITLE
SystemUI: Properly set qs status bar network traffic

### DIFF
--- a/packages/SystemUI/res/layout/quick_qs_status_icons.xml
+++ b/packages/SystemUI/res/layout/quick_qs_status_icons.xml
@@ -72,17 +72,6 @@
         android:layout_gravity="end|center_vertical"
         android:focusable="false"/>
 
-    <com.android.systemui.statusbar.policy.NetworkTraffic
-        android:id="@+id/networkTraffic"
-        android:paddingEnd="@dimen/status_bar_left_clock_end_padding"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_marginStart="2dp"
-        android:layout_marginEnd="2dp"
-        android:singleLine="false"
-        android:lineSpacingMultiplier="1.2"
-        systemui:showDark="false"/>
-
     <View
         android:id="@+id/separator"
         android:layout_width="0dp"


### PR DESCRIPTION
* Fixes duplicated network traffic view when set to expanded header.

Co-authored-by: Amsal Khan <md.amsalkhan@gmail.com>
Signed-off-by: cjh1249131356 <cjh1249131356@gmail.com>
Signed-off-by: Amsal Khan <md.amsalkhan@gmail.com>