### PR TITLE
Add FLAG_IMMUTABLE flag to PendingIntent

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -4970,7 +4970,7 @@ public class NotificationPanelViewController extends PanelViewController {
         AlarmManager alarmManager = (AlarmManager) mView.getContext().getSystemService(Context.ALARM_SERVICE);
         Intent intent = new Intent(CANCEL_NOTIFICATION_PULSE_ACTION);
         PendingIntent sender = PendingIntent.getBroadcast(mView.getContext(),
-                0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                0, intent, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         alarmManager.cancel(sender);
     }
 }


### PR DESCRIPTION
Fixes:
02-26 19:43:23.067 22173 22173 E AndroidRuntime: java.lang.IllegalArgumentException: com.android.systemui: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
02-26 19:43:23.067 22173 22173 E AndroidRuntime: Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.