### PR TITLE
VolumeDialog: Fix NPE in Dismiss

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogImpl.java
@@ -1473,7 +1473,7 @@ public class VolumeDialogImpl implements VolumeDialog,
                     mDialog.dismiss();
                     tryToRemoveCaptionsTooltip();
                     mExpanded = false;
-                    mExpandRows.setExpanded(mExpanded);
+                    if (mExpandRows != null) mExpandRows.setExpanded(mExpanded);
                     updateRowsH(mDefaultRow);
                     mDefaultRow = null;
                     mIsAnimatingDismiss = false;


### PR DESCRIPTION
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.android.systemui.statusbar.phone.ExpandableIndicator.setExpanded(boolean)' on a null object reference
at com.android.systemui.volume.VolumeDialogImpl.lambda$dismissH$21(VolumeDialogImpl.java:1476)